### PR TITLE
Add atom-slime to the list of IDEs

### DIFF
--- a/ides/summary.html
+++ b/ides/summary.html
@@ -14,6 +14,7 @@ layout: default
   <li><p><a href="http://www.cliki.net/MCLIDE">McClide</a> (OSX) - Maintained.</p></li>
   <li><p><a href="https://bitbucket.org/skolos/lispdev/overview">Cusp/Eclipse</a> - Unmaintained. <a href="cusp-setup.html">Articulate-Lisp cusp article</a></p></li>
   <li><p><a href="http://ufasoft.com/lisp/">Ufasoft</a> (Windows) - Unmaintained.</p></li>
+  <li><p><a href="https://atom.io/packages/atom-slime">Atom-SLIME</a> - Maintained. Integrates SLIME with Atom! This package allows you to interactively develop Common Lisp code, helping turn Atom into a full-featured Lisp IDE. </p></li>
 </ul>
 <h2 id="non-open-source">Non-open source</h2>
 <ul>


### PR DESCRIPTION
Add atom-slime, which is more accessible for non-Emacs- or Vim-users, to the list of IDEs.